### PR TITLE
Corrige problemas reportados pelo linter para `job-cards.css`

### DIFF
--- a/assets/css/job-cards.css
+++ b/assets/css/job-cards.css
@@ -118,7 +118,7 @@ h1.title {
     transform: scale(0);
     opacity: 0.2;
   }
-  
+
   100% {
     -webkit-transform: scale(20);
     transform: scale(20);

--- a/assets/css/job-cards.css
+++ b/assets/css/job-cards.css
@@ -2,8 +2,8 @@
 :root {
   --white: #fff;
   --color-text-primary: #828282;
-  --color-text-secondary: #333333;
-  --color-primary: #FDC435;
+  --color-text-secondary: #333;
+  --color-primary: #fdc435;
 }
 
 .btn {
@@ -26,7 +26,6 @@
   text-align: center;
   font-family: "Nunito", sans-serif;
 }
-
 
 .slides {
   position: relative;
@@ -94,6 +93,7 @@ h1.title {
   justify-content: space-between;
   margin: 0 -12px -12px;
 }
+
 [ripple] {
   z-index: 1;
   position: relative;
@@ -111,24 +111,28 @@ h1.title {
   -webkit-animation: ripple 2s;
   animation: ripple 2s;
 }
+
 @-webkit-keyframes ripple {
   0% {
     -webkit-transform: scale(0);
     transform: scale(0);
     opacity: 0.2;
   }
+  
   100% {
     -webkit-transform: scale(20);
     transform: scale(20);
     opacity: 0;
   }
 }
+
 @keyframes ripple {
   0% {
     -webkit-transform: scale(0);
     transform: scale(0);
     opacity: 0.2;
   }
+
   100% {
     -webkit-transform: scale(20);
     transform: scale(20);

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -156,8 +156,6 @@ const checkEndGame = function checkEndGame () {
   const numberPlays = cardsByLevel[level]
   if (numberPlays === matches) {
     endGame()
-  } else {
-    console.log(matches + ' matches')
   }
 }
 

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -283,10 +283,34 @@ function showModal () {
   modal.classList.add('show')
 }
 
+function playAgain() {
+  let modal = document.getElementById("popup_jogo");
+  modal.classList.remove("show");
+  let difficulty = document.querySelector('#difficulty');
+  difficulty.classList.remove('difficulty-hidden');
+  let game = document.querySelector('#game');
+  game.classList.remove('game-running')
+  game.classList.add('game-hidden')
+  let trackers = document.querySelector('#trackers')
+  trackers.classList.add('trackers-hidden');
+  let gameSection = document.querySelector("#js-game-section");
+  gameSection.classList.remove("hidden");
+  gameSection.classList.remove("active");
+  interval = "";
+  grid.innerHTML = "";
+  resetMatches();
+  resetJogadas();
+}
+
 function gameSetup () {
   startGame()
   resetMatches()
   resetJogadas()
   resetTimer()
   startTimer()
+}
+
+function playAgainLevels() {
+  clearTimeout(interval);
+  playAgain();
 }

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -283,12 +283,12 @@ function showModal () {
   modal.classList.add('show')
 }
 
-function playAgain() {
-  const modal = document.getElementById('popup_jogo');
+function playAgain () {
+  const modal = document.getElementById('popup_jogo')
   modal.classList.remove('show');
-  const difficulty = document.querySelector('#difficulty');
-  difficulty.classList.remove('difficulty-hidden');
-  const game = document.querySelector('#game');
+  const difficulty = document.querySelector('#difficulty')
+  difficulty.classList.remove('difficulty-hidden')
+  const game = document.querySelector('#game')
   game.classList.remove('game-running')
   game.classList.add('game-hidden')
   const trackers = document.querySelector('#trackers')
@@ -308,9 +308,4 @@ function gameSetup () {
   resetJogadas()
   resetTimer()
   startTimer()
-}
-
-function playAgainLevels() {
-  clearTimeout(interval)
-  playAgain()
 }

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -309,6 +309,6 @@ function gameSetup () {
 }
 
 function playAgainLevels () {
-  clearTimeout(interval);
-  playAgain();
+  clearTimeout(interval)
+  playAgain()
 }

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -284,22 +284,22 @@ function showModal () {
 }
 
 function playAgain() {
-  let modal = document.getElementById("popup_jogo");
-  modal.classList.remove("show");
-  let difficulty = document.querySelector('#difficulty');
+  const modal = document.getElementById('popup_jogo');
+  modal.classList.remove('show');
+  const difficulty = document.querySelector('#difficulty');
   difficulty.classList.remove('difficulty-hidden');
-  let game = document.querySelector('#game');
+  const game = document.querySelector('#game');
   game.classList.remove('game-running')
   game.classList.add('game-hidden')
-  let trackers = document.querySelector('#trackers')
-  trackers.classList.add('trackers-hidden');
-  let gameSection = document.querySelector("#js-game-section");
-  gameSection.classList.remove("hidden");
-  gameSection.classList.remove("active");
-  interval = "";
-  grid.innerHTML = "";
-  resetMatches();
-  resetJogadas();
+  const trackers = document.querySelector('#trackers')
+  trackers.classList.add('trackers-hidden')
+  const gameSection = document.querySelector('#js-game-section')
+  gameSection.classList.remove('hidden')
+  gameSection.classList.remove('active')
+  interval = ''
+  grid.innerHTML = ''
+  resetMatches()
+  resetJogadas()
 }
 
 function gameSetup () {
@@ -311,6 +311,6 @@ function gameSetup () {
 }
 
 function playAgainLevels() {
-  clearTimeout(interval);
-  playAgain();
+  clearTimeout(interval)
+  playAgain()
 }

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -283,7 +283,7 @@ function showModal () {
 
 function playAgain () {
   const modal = document.getElementById('popup_jogo')
-  modal.classList.remove('show');
+  modal.classList.remove('show')
   const difficulty = document.querySelector('#difficulty')
   difficulty.classList.remove('difficulty-hidden')
   const game = document.querySelector('#game')

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -307,3 +307,8 @@ function gameSetup () {
   resetTimer()
   startTimer()
 }
+
+function playAgainLevels () {
+  clearTimeout(interval);
+  playAgain();
+}


### PR DESCRIPTION
# Descrição

- Corrige todos os problemas reportados pelo linter para `job-cards.css`
- Reverte issue introduzido no [PR 50](https://github.com/As-Raparigas-do-Codigo/jogo-das-profissoes/pull/50), não era possível recomeçar jogo
- Corrige issues de linter para código resultado da reversão;
- Retira `console.log` desnecessário

Fixes #19 

# Como testar esta modificação

Validar em baixo no check de "Lint code base" se existe algum erro para o ficheiro `job-cards.css`.

# Checklist

- [x] O meu PR segue as regras de estilo de código deste projeto
- [x] Eu fiz uma autoavaliação (review) do meu próprio código ou materiais
- [x] Eu fiz as alterações correspondentes na documentação