### PR TITLE
59 corrected title position

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@
     - Garante que não és atribuída a mais do que um issue ao mesmo tempo;
 3. Um dos mentores **atribuirá** esse issue ao utilizador com o primeiro comentário;
 4. Quando o issue te for atribuído, faz **fork** do projecto - vê [aqui](https://github.com/As-Raparigas-do-Codigo/Recursos/blob/main/Git/Como_fazer_fork.md) como;
-5. Cria um **novo branch** no projecto que bifurcaste - vê [aqui](https://docs.github.com/pt/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) como;
+5. Cria um **novo branch** no projecto que bifurcaste - vê [aqui](https://docs.github.com/pt/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) como;
     - Garante que lhe dás um nome descritivo, ex.: "adicionar-botao-home"
 6. Tenta fazer **commits** com regularidade e escreve mensagens descritivas, ex.: "adiciona botão azul à página inicial";
 7. Quando terminares o teu trabalho faz um Pull Request (PR) para o branch `main` do repositório original - vê [aqui](https://docs.github.com/pt/github/getting-started-with-github/quickstart/fork-a-repo) como;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -544,8 +544,11 @@ span.play-button {
 
 @media (max-width: 767px) {
 	.container {
-		margin: auto;
+		
 		text-align: center;
+	}
+	.row {
+		margin: auto;
 	}
   }
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -542,6 +542,14 @@ span.play-button {
   color: #fdc134;
 }
 
+@media (max-width: 767px) {
+	.container {
+		margin: auto;
+		text-align: center;
+	}
+  }
+
+
 /* --------------------------------------------------------------
 # Contacts Menu
 -------------------------------------------------------------- */


### PR DESCRIPTION
# Descrição
Em ecrãs pequenos o título Jogo das Profissões e o seu conteúdo não se encontravam centrados. O objetivo desta alteração foi corrigir esse problema. 
<!-- Inclui um resumo das alterações e motivação / contexto relevante. Lista todas as dependências necessárias para essa mudança. -->

<!-- XXXX é o numero da tarefa/issue - isto é para quando fizermos merge desta alteração fechar a issue original automaticamente -->
Fixes #59


# Como testar esta modificação
Antes o titulo estava:
![titlenotcentered](https://user-images.githubusercontent.com/93822452/199124923-246906b8-7d94-49b8-922a-ee6d0801ac57.png)

Com a alteração:
![titlecentered](https://user-images.githubusercontent.com/93822452/199124985-0ed8f4f0-979f-4a78-aaf8-f6d3eaeea677.png)


<!-- Descreve os testes que executaste para verificar tuas alterações. Diz-nos as instruções ou GIFs para que possamos reproduzir. Lista todos os detalhes relevantes para o teu teste. -->


# Checklist

<!-- **Apaga as opções irrelevantes.** -->

- [x] O meu PR segue as regras de estilo de código deste projeto
- [x] Eu fiz uma autoavaliação (review) do meu próprio código ou materiais
- [x] Eu fiz as alterações correspondentes na documentação
